### PR TITLE
Bug #40 : Equal Size Of Calculators Display

### DIFF
--- a/style.css
+++ b/style.css
@@ -206,7 +206,8 @@ section {
 
 .container .box {
     position: relative;
-    width: 320px;
+    width: 300px;    /*  Adjust the size of calculators accordingly */
+    height: 300px;   /*  Adjust the size of calculators accordingly */
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
Closes Issue #40 

Description👨‍💻 

In the present interface the different calculators are in different size which gives an ODD look for the user.
So as a minor change has been done to resolve this issue.
This give a decent look to the overall project.

The changes made adds up to:
-a good interface to the project
-maintains regularity

#SWOC


# Checklist✅ 

- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have added demonstration in the form of GIF/video file
- [] I am an Open Source Contributor

# Screenshots/GIF📷


The changes made can be seen in the below attached screenshots.
**Before Making Changes:** 

![Sizes before 1](https://github.com/Rakesh9100/CalcDiverse/assets/112249927/86a11fa5-6e67-49ef-9ab8-54cf6e6941de)

**After Making Changes:**

![Sizes after 1](https://github.com/Rakesh9100/CalcDiverse/assets/112249927/4d9a865e-df5a-45ec-8bf3-1cfe290c207b)

