### PR TITLE
Fixed Issue #107 and Issue #108

### DIFF
--- a/style.css
+++ b/style.css
@@ -137,8 +137,7 @@ section {
     z-index: 200;
 }
 
-.comp-section .compcontainer h1 {
-    font-size: 7rem;
+.comp-section .compcontainer h1 { 
     text-shadow: 2px 2px 10px var(--light);
 }
 
@@ -356,7 +355,7 @@ section {
     }
 
     .compcontainer {
-        padding: 40px;
+        padding-top: 40px; /*Fixes #107 */
     }
 
     .compcontainer h1 {

--- a/style.css
+++ b/style.css
@@ -169,10 +169,10 @@ section {
 
 .paragraph {
     font-size: 2rem;
-    width: 70%;
+    width: 85%;
     text-align: center;
     margin: auto;
-    padding: 20px;
+    padding: 10px;
     color: var(--secondary);
 }
 
@@ -353,19 +353,21 @@ section {
         transition: 0.3s;
         box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
     }
-
+    .container{
+        margin-top: 170px;
+    }
     .compcontainer {
-        padding-top: 40px; /*Fixes #107 */
+        padding-top: 10px; /*Fixes #107 */
     }
 
     .compcontainer h1 {
         font-size: 400%;
-        padding-bottom: 40px;
+        padding-bottom: 10px;
     }
 
     .compcontainer h3 {
         font-size: 200%;
-        padding-bottom: 40px;
+        padding-bottom: 10px;
     }
 
     .compcontainer p {

--- a/style.css
+++ b/style.css
@@ -187,7 +187,7 @@ section {
 }
 
 .comp-section h1 {
-    font-size: 96px;
+    font-size: 65px;
 }
 
 .comp-section h3 {
@@ -321,6 +321,9 @@ section {
         height: 6rem;
         width: 50rem;
     }
+    .comp-section h1 {
+        font-size: 55px;
+    }
 }
 
 @media (max-width: 500px) {
@@ -361,7 +364,7 @@ section {
     }
 
     .compcontainer h1 {
-        font-size: 400%;
+        font-size: 300%;
         padding-bottom: 10px;
     }
 


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #107 & #108

# Description👨‍💻 

Issue #107 
The mail heading "Calcdiverse" font was exceeding the main container making it unresponsive on mobile screen. I have made the changes in overall padding and font size to make it mobile responsive. In addition to that I have updated the media queries as well, so that it doesn't conflict with the real code.

Issue #108 

The "2D Shapes Calculator" card on the mobile screen overlapped the "Explore Calculator" Button. I have made fixes by reducing the padding around the cards div and paragraph div and also added margin to the container in the media screen so that it works normally on all the screens and maintains the responsiveness of the website
# Type of change📄

# How this has been tested✅

I have checked the website after fixes via Chrome developer tools making various checks with all types of screens available. The fixes pass every screen parameter and maintain responsiveness.

# Checklist✅ 



- [x]  My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have added demonstration in the form of GIF/video file

- [x] I am an Open Source Contributor

# Screenshots/GIF📷
Before: 

Issue #107 
![Cd_mob](https://github.com/Rakesh9100/CalcDiverse/assets/33122840/22354ed3-32fb-4eb2-9248-31c6fb4472cd)

Issue#108
![cd_mob_overlap](https://github.com/Rakesh9100/CalcDiverse/assets/33122840/ead4c1d2-5b69-4a2e-8774-1eb4c1432e47)

After changes:-

Issue #107
![image](https://github.com/Rakesh9100/CalcDiverse/assets/33122840/4ee056ab-c953-4f08-ba9f-b53799ab39f3)

Issue#108
![image](https://github.com/Rakesh9100/CalcDiverse/assets/33122840/0d6652d1-0ddb-492a-8a90-ec92f4d35a83)

