### PR TITLE
[Feature] Added new measures in the length calculator

### DIFF
--- a/Calculators/Length-Calculator/Length.html
+++ b/Calculators/Length-Calculator/Length.html
@@ -18,7 +18,10 @@
         <label for="unitFrom">From</label>
         <select id="unitFrom">
           <option value="km" selected>Kilometers</option>
+          <option value="hm">Hectometers</option>
+          <option value="dam">Decameters</option>
           <option value="m">Meters</option>
+          <option value="dm">Decimeters</option>
           <option value="cm">Centimeters</option>
           <option value="mm">Millimeters</option>
         </select>
@@ -26,7 +29,10 @@
         <label for="unitTo">To</label>
         <select id="unitTo">
           <option value="km">Kilometers</option>
+          <option value="hm">Hectometers</option>
+          <option value="dam">Decameters</option>
           <option value="m" selected>Meters</option>
+          <option value="dm">Decimeters</option>
           <option value="cm">Centimeters</option>
           <option value="mm">Millimeters</option>
         </select>

--- a/Calculators/Length-Calculator/Length.js
+++ b/Calculators/Length-Calculator/Length.js
@@ -16,8 +16,11 @@ function convertLength() {
   
     let conversionFactors = {
       km: 1000,
+      hm: 100,
+      dam: 10,
       m: 1,
-      cm: 0.01,
+      dm: 0.1,
+      cm: 0.01, 
       mm: 0.001,
     };
   


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #340 

# Description👨‍💻 

I added new measures in the [Length Calculator](https://calcdiverse.netlify.app/calculators/length-calculator/length):
- Hectometre
- Decametre
- Decimetre

I added new options with those measures for both "unitFrom" and "unitTo" in the html code. 
```
<select id="unitTo">
          <option value="km">Kilometers</option>
          <option value="hm">Hectometers</option> NEW 
          <option value="dam">Decameters</option> NEW 
          <option value="m" selected>Meters</option>
          <option value="dm">Decimeters</option> NEW 
          <option value="cm">Centimeters</option>
          <option value="mm">Millimeters</option>
        </select>
Same goes for the unitFrom tag.
```
And for this to work I added the conversion factors for hm , dam and dm.
```
let conversionFactors = {
      km: 1000,
      hm: 100,
      dam: 10,
      m: 1,
      dm: 0.1,
      cm: 0.01, 
      mm: 0.001,
    };
```

The code works the same, but I added new options and new values. 
# Type of change📄

- [] New feature (non-breaking change which adds functionality)

# How this has been tested✅

I tested it in my localhost. Everything works fine.

# Checklist✅ 

- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have added demonstration in the form of GIF/video file
- [] I am an Open Source Contributor

# Screenshots/GIF📷

![contrib](https://github.com/Rakesh9100/CalcDiverse/assets/108179264/439b64a8-4788-4e42-bc5b-5a496fc6f41c)
![contrib2](https://github.com/Rakesh9100/CalcDiverse/assets/108179264/585d1eef-8cd0-4b8e-b2db-19012de1e780)
