### PR TITLE
Made home and contributor page font family consistent

### DIFF
--- a/assets/contributors/contributor.css
+++ b/assets/contributors/contributor.css
@@ -50,8 +50,6 @@ h1:hover {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    font-family: poppins;
-    font-family: Ubuntu;
 }
 
 div {
@@ -99,7 +97,7 @@ body {
     box-shadow: 0 0 20px rgb(188, 240, 210); /* Adjust the color and size of the glow as needed */
 }
 
-/* Updated Footer Styling */
+/* Footer Styling */
 
 .footer-basic {
     padding:40px 0;


### PR DESCRIPTION
# Fixes Issue🛠️ #421 

<!-- Example: Closes #31 -->

Closes #421 

# Description👨‍💻 
I have fixed the contributor.css file code and made the font family same for both the pages Navbar elements.
<!--Please include a summary of the change and which issue is fixed.List any dependencies that are required for this change.-->

# Type of change📄

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)

# How this has been tested✅

<!--Please describe the tests that you ran to verify your changes.-->

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I am an Open Source Contributor

# Screenshots/GIF📷
### Home Page(No change)
<img width="957" alt="homef" src="https://github.com/Rakesh9100/CalcDiverse/assets/104363876/0f584e6b-c9e2-4e35-bbf7-229e01f3fae0">

### Contributor Page (changed)
<img width="958" alt="contribf" src="https://github.com/Rakesh9100/CalcDiverse/assets/104363876/edd252e4-e841-401b-9155-08587acd0aca">

