### PR TITLE
Spelling fixed in Age Calculator Title

### DIFF
--- a/Calculators/Age-Calculator/Age-Calculator.html
+++ b/Calculators/Age-Calculator/Age-Calculator.html
@@ -1,53 +1,60 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Age Calculaor</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="Age-Calculator.css">
-    
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Age Calculator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@900&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="Age-Calculator.css" />
+  </head>
+  <body>
     <div id="container">
-        <div id="main">
-            <div id="heading"><h1>Age Calculator</h1></div>
+      <div id="main">
+        <div id="heading"><h1>Age Calculator</h1></div>
 
-            <div id="onemain">
-                <div id="oneone">
-                    <label for="ip1" id="ip1name">DOB - <input type="datetime-local" name="ip1" id="ip1"></label>
+        <div id="onemain">
+          <div id="oneone">
+            <label for="ip1" id="ip1name"
+              >DOB - <input type="datetime-local" name="ip1" id="ip1"
+            /></label>
 
-                    <label for="ip2" id="ip2name">Till - &nbsp;&nbsp;&nbsp;&nbsp;<input type="datetime-local" name="ip2" id="ip2"></label>
-                </div>
-                <div id="onetwo">
-                    <button type="button" onclick="calculateage()">Calculate</button>
-                </div>
-            </div>
-
-            <div id="twomain">
-                <div id="twoone">
-                    <img src="child1.svg" alt="child" id="photo">
-                </div>
-
-                <div id="twotwo">
-                    <h2 id="op1">Age = 0 Years 0 Months</h2>
-                    <br>
-                    <h2>OR</h2>
-                    <br>
-                    <h2 id="op2">- 0 Months</h2>
-                    <h2 id="op7">- 0 Weeks</h2>
-                    <h2 id="op3">- 0 Days</h2>
-                    <h2 id="op4">- 0 Hrs</h2>
-                    <h2 id="op5">- 0 Minutes</h2>
-                    <h2 id="op6">- 0 Seconds</h2>
-                </div>
-            </div>
-
+            <label for="ip2" id="ip2name"
+              >Till - &nbsp;&nbsp;&nbsp;&nbsp;<input
+                type="datetime-local"
+                name="ip2"
+                id="ip2"
+            /></label>
+          </div>
+          <div id="onetwo">
+            <button type="button" onclick="calculateage()">Calculate</button>
+          </div>
         </div>
 
+        <div id="twomain">
+          <div id="twoone">
+            <img src="child1.svg" alt="child" id="photo" />
+          </div>
+
+          <div id="twotwo">
+            <h2 id="op1">Age = 0 Years 0 Months</h2>
+            <br />
+            <h2>OR</h2>
+            <br />
+            <h2 id="op2">- 0 Months</h2>
+            <h2 id="op7">- 0 Weeks</h2>
+            <h2 id="op3">- 0 Days</h2>
+            <h2 id="op4">- 0 Hrs</h2>
+            <h2 id="op5">- 0 Minutes</h2>
+            <h2 id="op6">- 0 Seconds</h2>
+          </div>
+        </div>
+      </div>
     </div>
-</body>
-<script src="Age-Calculator.js"></script>
+  </body>
+  <script src="Age-Calculator.js"></script>
 </html>

--- a/Calculators/Age-Calculator/Age-Calculator.html
+++ b/Calculators/Age-Calculator/Age-Calculator.html
@@ -1,60 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Age Calculator</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Lato:wght@900&display=swap"
-      rel="stylesheet"
-    />
-    <link rel="stylesheet" href="Age-Calculator.css" />
-  </head>
-  <body>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="Age-Calculator.css">
+    
+</head>
+<body>
     <div id="container">
-      <div id="main">
-        <div id="heading"><h1>Age Calculator</h1></div>
+        <div id="main">
+            <div id="heading"><h1>Age Calculator</h1></div>
 
-        <div id="onemain">
-          <div id="oneone">
-            <label for="ip1" id="ip1name"
-              >DOB - <input type="datetime-local" name="ip1" id="ip1"
-            /></label>
+            <div id="onemain">
+                <div id="oneone">
+                    <label for="ip1" id="ip1name">DOB - <input type="datetime-local" name="ip1" id="ip1"></label>
 
-            <label for="ip2" id="ip2name"
-              >Till - &nbsp;&nbsp;&nbsp;&nbsp;<input
-                type="datetime-local"
-                name="ip2"
-                id="ip2"
-            /></label>
-          </div>
-          <div id="onetwo">
-            <button type="button" onclick="calculateage()">Calculate</button>
-          </div>
+                    <label for="ip2" id="ip2name">Till - &nbsp;&nbsp;&nbsp;&nbsp;<input type="datetime-local" name="ip2" id="ip2"></label>
+                </div>
+                <div id="onetwo">
+                    <button type="button" onclick="calculateage()">Calculate</button>
+                </div>
+            </div>
+
+            <div id="twomain">
+                <div id="twoone">
+                    <img src="child1.svg" alt="child" id="photo">
+                </div>
+
+                <div id="twotwo">
+                    <h2 id="op1">Age = 0 Years 0 Months</h2>
+                    <br>
+                    <h2>OR</h2>
+                    <br>
+                    <h2 id="op2">- 0 Months</h2>
+                    <h2 id="op7">- 0 Weeks</h2>
+                    <h2 id="op3">- 0 Days</h2>
+                    <h2 id="op4">- 0 Hrs</h2>
+                    <h2 id="op5">- 0 Minutes</h2>
+                    <h2 id="op6">- 0 Seconds</h2>
+                </div>
+            </div>
+
         </div>
 
-        <div id="twomain">
-          <div id="twoone">
-            <img src="child1.svg" alt="child" id="photo" />
-          </div>
-
-          <div id="twotwo">
-            <h2 id="op1">Age = 0 Years 0 Months</h2>
-            <br />
-            <h2>OR</h2>
-            <br />
-            <h2 id="op2">- 0 Months</h2>
-            <h2 id="op7">- 0 Weeks</h2>
-            <h2 id="op3">- 0 Days</h2>
-            <h2 id="op4">- 0 Hrs</h2>
-            <h2 id="op5">- 0 Minutes</h2>
-            <h2 id="op6">- 0 Seconds</h2>
-          </div>
-        </div>
-      </div>
     </div>
-  </body>
-  <script src="Age-Calculator.js"></script>
+</body>
+<script src="Age-Calculator.js"></script>
 </html>


### PR DESCRIPTION
# Fixes Issue🛠️

<!-- Example: Closes #31 -->

Closes #468 

# Description👨‍💻 

<!--Please include a summary of the change and which issue is fixed.List any dependencies that are required for this change.-->
There was a spelling error in the page title of the age calculator page. This has been replaced with the correct spelling.
# Type of change📄

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

# How this has been tested✅

<!--Please describe the tests that you ran to verify your changes.-->
The page title is named with the correctly spelled word


# Checklist✅ 

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added demonstration in the form of GIF/video file
- [X] I am an Open Source Contributor

# Screenshots/GIF📷
![image](https://github.com/Rakesh9100/CalcDiverse/assets/56074740/5256654a-03d0-4cbd-87a8-6697cebfdac5)
