### PR TITLE
Fixed the displayed html tag in Armstrong Number Calculator

### DIFF
--- a/Calculators/Armstrong-Number-Calculator/index.html
+++ b/Calculators/Armstrong-Number-Calculator/index.html
@@ -15,7 +15,7 @@
     <main>
         <div class="container">
             <form name="myform">
-                <label for="no">Enter Number of Digits (should be <=7):< /label>
+                <label for="no"Enter Number of Digits (should be <=7):< /label>
                         <input type="number" name="numOfDigits" id="no">
                         <button type="button" onclick="findArmstrongNumbers()">Find Armstrong Numbers</button>
             </form>

--- a/Calculators/Armstrong-Number-Calculator/index.html
+++ b/Calculators/Armstrong-Number-Calculator/index.html
@@ -15,7 +15,7 @@
     <main>
         <div class="container">
             <form name="myform">
-                <label for="no"Enter Number of Digits (should be <=7):< /label>
+                <label for="no">Enter Number of Digits (should be <=7):</label>
                         <input type="number" name="numOfDigits" id="no">
                         <button type="button" onclick="findArmstrongNumbers()">Find Armstrong Numbers</button>
             </form>


### PR DESCRIPTION
# Fixes Issue🛠️ 
<!-- Example: Closes #31 -->

Closes #655 

# Description👨‍💻 

<!--Please include a summary of the change and which issue is fixed.List any dependencies that are required for this change.-->
The html code </label> was being displayed on the website which is fixed now.

# Type of change📄

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)

# How this has been tested✅
Tested locally.
<!--Please describe the tests that you ran to verify your changes.-->

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added demonstration in the form of GIF/video file
- [x] I am an Open Source Contributor

# Screenshots/GIF📷

![image](https://github.com/Rakesh9100/CalcDiverse/assets/73993775/091447e4-58ee-4edd-8830-46039b5443dd)
