### PR TITLE
Fixed the displayed html tag in Armstrong Number Calculator

### DIFF
--- a/Calculators/Armstrong-Number-Calculator/index.html
+++ b/Calculators/Armstrong-Number-Calculator/index.html
@@ -15,7 +15,7 @@
     <main>
         <div class="container">
             <form name="myform">
-                <label for="no">Enter Number of Digits (should be <=7):< /label>
+                <label for="no">Enter Number of Digits (should be <=7):</label>
                         <input type="number" name="numOfDigits" id="no">
                         <button type="button" onclick="findArmstrongNumbers()">Find Armstrong Numbers</button>
             </form>


### PR DESCRIPTION
# Fixes Issue🛠️

 armstrong calculator display html code : Closes #655  



# Description👨‍💻 

Issue was very simple, There was an extra space in the code which was causing it to display the html tag as normal text..

# Type of change📄

- [] Bug fix (non-breaking change which fixes an issue)

# How this has been tested✅
Ran on the local machine and verified that its fixed.

# Checklist✅ 

- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have added demonstration in the form of GIF/video file
- [] I am an Open Source Contributor

# Screenshots/GIF📷
![Screenshot 2024-05-10 211027](https://github.com/Rakesh9100/CalcDiverse/assets/84931030/622376ef-3556-4ed2-86e0-8816bee8084f)