### PR TITLE
Fixed the link to open Currency Calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,7 +571,7 @@
                 <h2>Currency Calculator</h2>
                 <h3>Converts the value of one Currency unit into another Currency unit.</h3>
                 <div class="card-footer">
-                    <a href="./Calculators/Currency-Calculator/Currency-Calculator.html" target="_blank">
+                    <a href="./Calculators/Currency-Calculator/index.html" target="_blank">
                         <button>Try Now</button>
                     </a>
                     <a href="https://github.com/Rakesh9100/CalcDiverse/tree/main/Calculators/Currency-Calculator" title="Source Code" target="_blank">


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #668 

# Description👨‍💻 

I have noticed that the source code is available when I click on it.
So it's really the page not found.
So I checked the route/path which is responsible to load currency calculator.
So, I have fixed the path and now it's properly working.

# Type of change📄

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

# How this has been tested✅

https://github.com/Rakesh9100/CalcDiverse/assets/112798996/26e6a5c3-f990-4bc0-bd21-38dbce4bce0b

The above shows the proper working of the site.

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added demonstration in the form of GIF/video file
- [x] I am an Open Source Contributor
