### PR TITLE
Implemented length constraint for message in Contact Us form

### DIFF
--- a/assets/contact/contact.js
+++ b/assets/contact/contact.js
@@ -18,3 +18,16 @@ function mobileMenu() {
     ham.classList.toggle("active");
     navMe.classList.toggle("active");
 }
+
+// text message length not less than 50 chars
+document.addEventListener('DOMContentLoaded', function() {
+    const contactForm = document.getElementById('contact-form');
+    const messageInput = document.getElementById('message');
+
+    contactForm.addEventListener('submit', function(event) {
+        if (messageInput.value.length < 50) {
+            event.preventDefault();
+            alert('Your message must be at least 50 characters long.');
+        }
+    });
+});


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #872 

# Description👨‍💻 

In the contact us form, a check over message length has been applied such that length of message should be at least 50 chars.
It'll help to avoid receiving empty 1-2 character messages which others may send without any purpose.

This may help in decluttering the message piles being received.

# Type of change📄

- [x] New feature (non-breaking change which adds functionality)

# How this has been tested✅

Tested locally on my system. Screenshot for the same has been attached.

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added demonstration in the form of GIF/video file
- [x] I am an Open Source Contributor

# Screenshots/GIF📷
![image](https://github.com/Rakesh9100/CalcDiverse/assets/116306749/6749aa71-461e-4843-aee8-9ada1a855f65)
