### PR TITLE
Made the color of logo text same on hover

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "liveServer.settings.port": 5501
-}

--- a/style.css
+++ b/style.css
@@ -244,7 +244,7 @@ nav ul {
 }
 
 .logo:hover {
-    color: #b400a5;
+    color: #ff1b82;;
 }
 
 .hamburger {


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #887

# Description👨‍💻 

Changed the color of logo text CalcDiverse in the navbar on the main page to make the color on whole navbar similar.

# Type of change📄

- [x] New feature (non-breaking change which adds functionality)

# How this has been tested✅

Tested locally on my PC. Screenshot of the same has been attached.!

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added demonstration in the form of GIF/video file
- [x] I am an Open Source Contributor

# Screenshots/GIF📷

![image](https://github.com/Rakesh9100/CalcDiverse/assets/116306749/0d7d4d12-73d5-4f93-a430-069c9520e034)
