### PR TITLE
Template for the Core Contributors

### DIFF
--- a/assets/contributors/contributor.html
+++ b/assets/contributors/contributor.html
@@ -60,6 +60,24 @@
         </nav>
     </header>
 
+    <!-- Core Contributors Section -->
+    <h1 class="heroes">Core Contributers</h1>
+    <div style="display: flex; justify-content: space-around;">
+        <div>
+        <img src="" alt="hello"  class="placeholder">
+        <p style="color: white;">Hello Dev here</p>
+        </div>
+        <div>
+        <img src="" alt="hello"  class="placeholder">
+        <p style="color: white;">Hello Dev here</p>
+        </div>
+        <div>
+        <img src="" alt="hello"  class="placeholder">
+        <p style="color: white;">Hello Dev here</p>
+        </div>
+    </div>
+            
+   
     <h1 class="heroes">Faces of Dedication: Our Contributing Heroes</h1>
     
     <div id="contributor">


### PR DESCRIPTION
In the '/contributors/contributor.html' page, added the Core Contributors section template in the repo, so when we have actual data it can be just inserted in the images src and the page will work as expected.

