### PR TITLE
Fix Overlapping text problem

### DIFF
--- a/Calculators/Clothing-Size-Calculator/index.html
+++ b/Calculators/Clothing-Size-Calculator/index.html
@@ -51,6 +51,7 @@
         <div class="result-box">
             <div id="resultSize">Size in <span class="red">--</span> : <span class="grey">--</span></div>
             <div id="internationalSize">International Size : <span class="red">--</span></div>
+            <br/><br> 
             <div id="measurement">Bust : <span class="grey">--</span> | Waist : <span class="grey">--</span> | Hip :
                 <span class="grey">--</span>
             </div>


### PR DESCRIPTION
# Fixes Issue🛠️
#1687 



# Description👨‍💻
The reference link was overlapping with the result output on the page.



# Type of Change📄
I addressed this issue by using a `<br/>` break line element to prevent overlap.




- [ ✅] Style (non-breaking change which improves website style or formatting)


# Checklist:
- [ ✅] I am an Open Source contributor
- [ ✅] I have performed a self-review of my code
- [✅ ] My code follows the style guidelines of this project
- [✅ ] I have commented on my code, particularly in hard-to-understand areas

# Screenshots/GIF📷
![Screenshot (340)](https://github.com/user-attachments/assets/cbceff7c-a279-4077-8a82-72f7af89080a)


