### PR TITLE
Fixed the zero calculation in Pythagorean Theorem Calculator

### DIFF
--- a/Calculators/Pythagorean-Theorem-Calculator/script.js
+++ b/Calculators/Pythagorean-Theorem-Calculator/script.js
@@ -2,8 +2,8 @@ function calculate() {
     var sideA = parseFloat(document.getElementById('sideA').value);
     var sideB = parseFloat(document.getElementById('sideB').value);
 
-    if (isNaN(sideA) || isNaN(sideB)) {
-        alert("Please enter valid numerical values for side A and side B.");
+    if (isNaN(sideA) || isNaN(sideB) || sideA <= 0 || sideB <= 0) {
+        alert("It looks like one or both of your inputs are missing or not positive. Please enter positive values for both sides.");
         return;
     }
 


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #1811 

# Description👨‍💻

This pull request addresses the bug where the hypotenuse was incorrectly calculated when one of the sides was entered as zero. The updated implementation now correctly handles this case.

# Type of Change📄

- [x] Bug fix (non-breaking change which fixes a bug)

# Checklist✅

- [x] I am an Open Source contributor
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas

# Screenshots/GIF📷

![image](https://github.com/user-attachments/assets/9ab597a4-7c21-4015-80d0-9fb78bf00275)
