### PR TITLE
Added dark mode to FAQ page

### DIFF
--- a/assets/faq/faq.css
+++ b/assets/faq/faq.css
@@ -9,7 +9,6 @@
     transform: translate(-50%, -50%);
 }
 
-
 .circle::before {
     content: "";
     position: fixed;

--- a/assets/faq/faq.css
+++ b/assets/faq/faq.css
@@ -9,6 +9,7 @@
     transform: translate(-50%, -50%);
 }
 
+
 .circle::before {
     content: "";
     position: fixed;

--- a/assets/faq/faq.html
+++ b/assets/faq/faq.html
@@ -77,7 +77,12 @@
                 <li class="nav-item">
                     <a href="../contact/contact.html" class="nav-link"><i class="fa fa-phone" aria-hidden="true"></i> Contact</a>
                 </li>
-
+                <div class="theme-switch-wrapper">
+                    <label class="theme-switch" for="checkbox">
+                        <input type="checkbox" id="checkbox">
+                        <div class="slider round"></div>
+                    </label>
+                </div>
             </ul>
             <div class="hamburger">
                 <span class="bar"></span>


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #1892 

# Description👨‍💻
<!-- Please include a summary of your changes. -->

This PR introduces dark mode support to the FAQ page. Dark mode enhances the user experience for those who prefer a dark interface or access the website in low-light environments. By providing a dark mode option, this update improves accessibility and aligns the FAQ page with modern UI standards.

# Type of Change📄
<!-- Please delete the options that are not relevant to you. -->
 
- [X] Style (non-breaking change which improves website style or formatting) 

# Checklist✅
<!-- Please delete the options that are not relevant to you. -->

- [X] I am an Open Source contributor
- [X] I have performed a self-review of my code
- [X] My code follows the style guidelines of this project

# Screenshots/GIF📷
<!-- Please add screenshots or a GIF to demonstrate your changes. -->

![image](https://github.com/user-attachments/assets/bdaaf6e2-3d57-4a2c-9328-de270cfd7cc3)
