### PR TITLE
Enhanced the google translate dropdown

### DIFF
--- a/style.css
+++ b/style.css
@@ -420,29 +420,24 @@ nav ul {
 
 /* Google Translate Css */
 
-.compcontainer {
-    position: relative;
-}
 #google_translate_element {
+    right: 0;
+    margin-top: 10px;
+    margin-right: 10px;
     position: absolute;
-    top: 10px;
-    right: 10px;
-    background: linear-gradient(135deg, #001aff, #03893e, rgba(255, 0, 89, 0.7), #ffe10c);
-    background-size: 300% 300%;
+    background: linear-gradient(135deg, #4caf50, #2196f3, #ff9800, #e91e63);
+    background-size: 200% 200%;
     border-radius: 8px;
     padding: 8px 12px;
     box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
-    z-index: 9999;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     animation: movingGradient 3s infinite linear;
 }
+
 .goog-te-combo {
     background: white;
     color: #6a11cb;
     font-family: 'Arial', sans-serif;
-    font-size: 14px;
+    font-weight: 600;
     border: 1px solid #6a11cb;
     border-radius: 5px;
     padding: 5px 10px;
@@ -451,11 +446,20 @@ nav ul {
     transition: all 0.3s ease-in-out;
     width: 100%;
 }
+
+.goog-te-combo option {
+    font-weight: 600;
+}
+
 .goog-te-combo:hover {
     background: #f2f2f2;
     border-color: #2575fc;
 }
 
+.goog-te-gadget {
+    color: white !important;
+    font-weight: 600;
+}
 
 @keyframes movingGradient {
     0% {
@@ -468,8 +472,6 @@ nav ul {
         background-position: 0% 50%;
     }
 }
-
-
 
 /* Components Section Css */
 

--- a/style.css
+++ b/style.css
@@ -420,12 +420,56 @@ nav ul {
 
 /* Google Translate Css */
 
-#google_translate_element {
-    right: 0;
-    margin-top: 5px;
-    margin-right: 5px;
-    position: absolute;
+.compcontainer {
+    position: relative;
 }
+#google_translate_element {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: linear-gradient(135deg, #001aff, #03893e, rgba(255, 0, 89, 0.7), #ffe10c);
+    background-size: 300% 300%;
+    border-radius: 8px;
+    padding: 8px 12px;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: movingGradient 3s infinite linear;
+}
+.goog-te-combo {
+    background: white;
+    color: #6a11cb;
+    font-family: 'Arial', sans-serif;
+    font-size: 14px;
+    border: 1px solid #6a11cb;
+    border-radius: 5px;
+    padding: 5px 10px;
+    outline: none;
+    cursor: pointer;
+    transition: all 0.3s ease-in-out;
+    width: 100%;
+}
+.goog-te-combo:hover {
+    background: #f2f2f2;
+    border-color: #2575fc;
+}
+
+
+@keyframes movingGradient {
+    0% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 50%;
+    }
+}
+
+
 
 /* Components Section Css */
 


### PR DESCRIPTION
# Fixes Issue🛠️
<!-- Example: Closes #32 -->

Closes #1887 

# Description👨‍💻
<!-- Please include a summary of your changes. -->

This PR addresses the issue of the outdated and simplistic design of the Google Translate dropdown on the CalcDiverse website. The dropdown currently lacks modern, visually appealing design elements, which affects the overall user experience. This update aims to improve the dropdown's style to make it more user-friendly and cohesive with the website's design language.

> A dynamic linear gradient background featuring the colors of Google (blue, red, yellow, and green) has been added, creating a vibrant and engaging visual experience. This gradient moves smoothly, adding a modern touch.

# Type of Change📄
<!-- Please delete the options that are not relevant to you. -->
 
- [X] Style (non-breaking change which improves website style or formatting)
 
# Checklist✅
<!-- Please delete the options that are not relevant to you. -->

- [X] I am an Open Source contributor
- [X] I have performed a self-review of my code
- [X] My code follows the style guidelines of this project

# Screenshots/GIF📷
<!-- Please add screenshots or a GIF to demonstrate your changes. -->

## In dark mode
![image](https://github.com/user-attachments/assets/9dc36dd9-3a04-4599-8f1a-ed7b0c3e5969)

## In light mode
![image](https://github.com/user-attachments/assets/b49605e4-9bb6-402b-acb8-3cd969871b18)
