### PR TITLE
fix: prevent background image from repeating in 2D Distance Calculator

### DIFF
--- a/Calculators/2D-Distance-Calculator/style.css
+++ b/Calculators/2D-Distance-Calculator/style.css
@@ -6,6 +6,9 @@ body {
     height: 100vh;
     margin: 0;
     background-image: url('assets/background.jpeg');
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    background-position: center;
     color: #ecf0f1;
 }
 


### PR DESCRIPTION
# Fixes Issue🛠️
<!-- Example: Closes #32 -->

Closes #2002 

# Description👨‍💻
<!-- Please include a summary of your changes. -->

The background image on the 2D Distance Calculator page was repeating and looked unprofessional.  
This PR fixes the issue by adding the following styles:
- `background-repeat: no-repeat;`
- `background-size: 100% 100%;`
- `background-position: center;`

Now, the background image displays correctly without repeating and is visually aligned.

# Type of Change📄
<!-- Please delete the options that are not relevant to you. -->

- [x] Style (non-breaking change which improves website style or formatting)

# Checklist✅
<!-- Please delete the options that are not relevant to you. -->

- [x] I am an Open Source contributor
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project

# Screenshots/GIF📷
<!-- Please add screenshots or a GIF to demonstrate your changes. -->

![image](https://github.com/user-attachments/assets/eb1c6e21-3776-490e-9638-391635849635)


